### PR TITLE
feat(commitizen): generate config file in consuming repository

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,0 +1,10 @@
+{
+  "path": "cz-conventional-changelog",
+  "maxHeaderWidth": 72,
+  "maxLineWidth": 72,
+  "defaultType": "",
+  "defaultScope": "",
+  "defaultSubject": "",
+  "defaultBody": "",
+  "defaultIssues": ""
+}

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -3,3 +3,18 @@
 if [ ! -f "${INIT_CWD}/.huskyrc.js" ]; then
   echo "module.exports = require('@weahead/husky-config');" > "${INIT_CWD}/.huskyrc.js"
 fi
+
+if [ ! -f "${INIT_CWD}/.cz.json" ]; then
+  cz='{
+  "path": "cz-conventional-changelog",
+  "maxHeaderWidth": 72,
+  "maxLineWidth": 72,
+  "defaultType": "",
+  "defaultScope": "",
+  "defaultSubject": "",
+  "defaultBody": "",
+  "defaultIssues": ""
+}
+'
+  echo "${cz}" >"${INIT_CWD}/.cz.json"
+fi


### PR DESCRIPTION
We found that Commitizen actually DOES support repository-level configuration

https://github.com/commitizen/cz-cli/blob/a70c063b06dbdf41af322dab06f83bfddd69149b/src/commitizen/configLoader.js#L6

So instead of #2 and `@weahead/commitizen` we'll go with the approach in this PR instead.

Closes #2 