### PR TITLE
feat(pre-commit): check for author e-mail domain to match @weahead.se

### DIFF
--- a/helpers/pre-commit.sh
+++ b/helpers/pre-commit.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+at_count=$(echo "${GIT_AUTHOR_EMAIL}" | tr -cd '@' | wc -c | tr -d ' ')
+if [ "${at_count}" = "1" ]; then
+  case "${GIT_AUTHOR_EMAIL}" in
+  *@weahead.se)
+    exit 0
+    ;;
+  esac
+fi
+echo ""
+echo "Author e-mail of \"${GIT_AUTHOR_EMAIL}\" is not correct."
+echo "A @weahead.se e-mail is required to create a commit in this repository."
+echo ""
+echo "A recommended approach is to create or update your local git configuration for this repository."
+echo "NOTE: This will make you commit with your @weahead.se e-mail address ONLY in this repository."
+echo "To commit as your @weahead.se e-mail address in ANOTHER repository, you would have to run the same command in that repository too."
+echo "To create or update your local git configuration for this repository run the following:"
+echo "git config --local user.name \"Your Name\""
+echo "git config --local user.email \"your.name@weahead.se\""
+echo ""
+echo "Another, less recommended but also viable approach, is to create or update your global git configuration."
+echo "NOTE: This will make you commit with your @weahead.se e-mail address in ALL your repositories/clones."
+echo "To create or update your global git configuration run the following:"
+echo "git config --global user.name \"Your Name\""
+echo "git config --global user.email \"your.name@weahead.se\""
+echo ""
+exit 1

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const cmd = `${isYarn ? 'yarn' : 'npm'} install`;
 
 module.exports = {
   hooks: {
-    'pre-commit': 'lint-staged',
+    'pre-commit': `${basePath}/helpers/pre-commit.sh && lint-staged`,
     'prepare-commit-msg': `${basePath}/helpers/prepare-commit-msg.sh`,
     'commit-msg': 'commitlint -E HUSKY_GIT_PARAMS',
     'post-merge': `package-change-checker --install-cmd="${cmd}"`,


### PR DESCRIPTION
This PR adds a check to `pre-commit` phase to check that the domain for the commit authors e-mail address matches `@weahead.se`

There have been too many occurrences of devs commiting with their non-weahead e-mail addresses. This should help mitigate that going forward. After this is merged and published we should go over each repository and rewrite all the commits author e-mails to be their @weahead.se counterparts.

Some things to discuss before merge:

- Should the error message be more "urgent" (red, bold, something else)? See screenshot <img width="1314" alt="Screenshot 2020-01-01 at 18 43 40" src="https://user-images.githubusercontent.com/487039/71644397-f5ab9c00-2cc7-11ea-93af-fd38baedb56b.png">
- First pass of the error message I included the "replace Your Name with your real name" part, but I think that your developers should be smart enough to get that without that explanation, right?
- Is the error message good enough?
